### PR TITLE
Improve LDAP User Authentication Support

### DIFF
--- a/lstu.conf.template
+++ b/lstu.conf.template
@@ -134,12 +134,12 @@
     # please note that everybody can still use shortend URLs
     # optional, no default
     #ldap => {
-    #    uri         => 'ldaps://ldap.example.org',
-    #    user_tree   => 'ou=users,dc=example,dc=org',
-    #    bind_dn     => ',ou=users,dc=example,dc=org',
-    #    bind_user   => 'uid=ldap_user',
-    #    bind_pwd    => 'secr3t',
-    #    user_filter => '!(uid=ldap_user)'
+    #    uri         => 'ldaps://ldap.example.org',                 # server URI
+    #    user_tree   => 'ou=users,dc=example,dc=org',               # search base DN
+    #    bind_dn     => 'uid=ldap_user,ou=users,dc=example,dc=org', # search bind DN
+    #    bind_pwd    => 'secr3t',                                   # search bind password
+    #    user_attr   => 'uid',                                      # user attribute (uid, mail, sAMAccountName, etc.)
+    #    user_filter => '(!(uid=ldap_user))',                       # user filter (to exclude some users, etc.)
     #},
 
     # set `htpasswd` if you want to use an htpasswd file instead of ldap


### PR DESCRIPTION
LDAP servers often have their users grouped into nested hierarchies,
usually consisting of Organizational Units (OU). This commit extends the
LDAP support so that it can locate the correct user in a server with a
nested hierarchy.

Different LDAP server schemas often use a different attribute for the
username. For example, Microsoft Active Directory commonly uses the
"sAMAccountName" as a username, while many other LDAP servers commonly
use the "uid" attribute as a username. This commit extends the LDAP
support so that the user can choose which attribute to use in the
configuration file, using the "user_attr" configuration setting.

With both of these changes in place, it now makes sense to merge the
configuration settings "bind_user" and "bind_dn" together into the
single configuration setting "bind_dn". The configuration settings now
match my expectations as an experienced LDAP administrator.

The configuration template has been updated to match these changes. In
addition, the LDAP section in the configuration template has improved
comments to explain the meaning of each setting.