### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+docker-compose.yml
+local
+lstu.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:jessie-slim
+
+# install operating system level packages
+RUN apt-get -y update \
+        && apt-get -y install \
+            build-essential \
+            libmysqld-dev \
+            libpng-dev \
+            libpq-dev \
+            libssl-dev \
+            openssl \
+        && rm -rf /var/lib/apt/lists/*
+
+# install Carton
+RUN cpan Carton \
+        && rm -rf ~/.cpan
+
+# install LSTU
+COPY . /lstu/
+WORKDIR /lstu
+RUN rm -rf log \
+        && make installdeps \
+        && rm -rf local/cache \
+        && rm -rf ~/.cpanm
+
+# run as uid/gid daemon:daemon
+USER daemon:daemon
+
+# start lstu web server
+ENTRYPOINT [ "carton", "exec", "hypnotoad", "-f", "script/lstu" ]


### PR DESCRIPTION
This commit adds a Dockerfile that can be used to build a Docker image
for running LSTU. This image lets the user have full control over the lstu.conf
configuration file, rather than trying to configure everything via environment
variables.