### PR TITLE
[fix] Remove URL creation form from 404

### DIFF
--- a/lib/Lstu/Controller/URL.pm
+++ b/lib/Lstu/Controller/URL.pm
@@ -234,7 +234,7 @@ sub get {
                 my $c = shift;
 
                 $c->render(
-                    template => 'index',
+                    template => '404',
                     msg      => $msg
                 );
             }

--- a/themes/default/templates/404.html
+++ b/themes/default/templates/404.html
@@ -1,0 +1,3 @@
+% # vim:set sw=4 ts=4 sts=4 ft=html.epl expandtab:
+% title 'Lstu';
+    <h3 class="alert alert-danger"><%= l('This address does not exist') %></h3>

--- a/themes/milligram/templates/404.html
+++ b/themes/milligram/templates/404.html
@@ -1,0 +1,3 @@
+% # vim:set sw=4 ts=4 sts=4 ft=html.epl expandtab:
+% title 'Lstu';
+    <h3 class="alert alert-danger"><%= l('This address does not exist') %></h3>


### PR DESCRIPTION
## The problem

With ldap config activated, the url creation form is available if we are going onto non existing link.

## The solution
Here i simply hide this form by creating a 404 page in templates... 
A better solution could exist.

Todo:

- I didn't check if API is available too
- I don't know how work the i18n tool chain of lstu, so i have not added the i18n key